### PR TITLE
blocking assignment to clock 

### DIFF
--- a/testbenches/assertions/ff_tb.sv
+++ b/testbenches/assertions/ff_tb.sv
@@ -28,7 +28,7 @@ module ff_no_en_tb #(
     );
 
     initial begin : generate_clock
-        forever #5 clk = ~clk;
+        forever #5 clk <= ~clk;
     end
 
     initial begin : drive_inputs


### PR DESCRIPTION
This can lead to race conditions because the clock signal is going to DUT.