### PR TITLE
Make mealy_tb compatible with Icarus Verilog

### DIFF
--- a/fsm/mealy_tb.sv
+++ b/fsm/mealy_tb.sv
@@ -19,7 +19,7 @@ module mealy_tb;
     end
 
     initial begin
-        $timeformat(-9, 0, " ns");
+        $timeformat(-9, 0, " ns", 0);
 
         // Reset the FSM.
         rst <= 1'b1;


### PR DESCRIPTION
Icarus Verilog requires $timeformat to have 0 or 4 arguments. Added a 0 as the last argument to fix compatibility. There are many other uses of timeformat in the code base, but starting with this one to get your input.